### PR TITLE
fix: example mentions `web::Data` but refers to plain state struct

### DIFF
--- a/examples/application/src/mutable_state.rs
+++ b/examples/application/src/mutable_state.rs
@@ -17,7 +17,7 @@ async fn index(data: web::types::State<AppStateWithCounter>) -> String {
 // <make_app_mutable>
 #[ntex::main]
 async fn main() -> std::io::Result<()> {
-    // Note: web::Data created _outside_ HttpServer::new closure
+    // Note: app state created _outside_ HttpServer::new closure
     let counter = AppStateWithCounter {
         counter: Mutex::new(0),
     };


### PR DESCRIPTION
The mutable app state example at https://ntex.rs/docs/application#shared-mutable-state mentions `web::Data`.

Since what is being created is a plain struct, the example's comment is  reworded to `// Note: app state created _outside_ HttpServer::new closure`.

Closes https://github.com/ntex-rs/website/issues/10